### PR TITLE
Cleanup

### DIFF
--- a/cleanup-intel.sh
+++ b/cleanup-intel.sh
@@ -8,17 +8,17 @@ OPENVINO_NOTEBOOK=$(oc get Notebook -n redhat-ods-applications -o name)
 echo "deleting Openvino Notebook resource"
 oc delete $OPENVINO_NOTEBOOK -n redhat-ods-applications
 
-OVMS_CSV=$(oc get subscription ovms-operator -n openshift-operators -o go-template='{{.status.currentCSV}}')
+OVMS_CSV=$(oc get subscription ovms-operator -n openshift-operators -o jsonpath='{.status.installedCSV}')
 echo "deleting sub ovms-operator"
 echo "deleting csv ${OVMS_CSV}"
 oc delete subscription ovms-operator -n openshift-operators
 oc delete clusterserviceversion ${OVMS_CSV} -n openshift-operators
 
 AIKIT_CONTAINER_NAME=$(oc get AIKitContainer -n redhat-ods-applications -o name)
-echo "deleteing AIKit Container resource"
+echo "deleting AIKit Container resource"
 oc delete $AIKIT_CONTAINER_NAME -n redhat-ods-applications
 
-AIKIT_CSV=$(oc get subscription aikit-operator -n openshift-operators -o json)
+AIKIT_CSV=$(oc get subscription aikit-operator -n openshift-operators -o jsonpath='{.status.installedCSV}')
 echo "deleting sub aikit-operator"
 echo "deleting csv ${AIKIT_CSV}"
 oc delete subscription aikit-operator -n openshift-operators

--- a/setup-intel.sh
+++ b/setup-intel.sh
@@ -8,8 +8,14 @@ oc apply -f "${DIR}/intel/aikit-operator-subscription.yaml"
 oc apply -f "${DIR}/intel/ovms-operator-subscription.yaml"
 
 echo "Waiting for 60s to allow operators to install"
-oc wait csv/aikit-operator.v2021.2.102120 -n openshift-operators --for=jsonpath='{.status.phase}'=Succeeded --timeout=60s
-oc wait csv/openvino-operator.v1.0.0 -n openshift-operators --for=jsonpath='{.status.phase}'=Succeeded --timeout=60s
+
+oc wait subscription/aikit-operator -n openshift-operators --for=jsonpath='{.status.state}'=AtLatestKnown --timeout=60s
+AIKIT_CSV=$(oc get subscription aikit-operator -n openshift-operators -o jsonpath='{.status.installedCSV}')
+oc wait csv/${AIKIT_CSV} -n openshift-operators --for=jsonpath='{.status.phase}'=Succeeded --timeout=60s
+
+oc wait subscription/ovms-operator -n openshift-operators --for=jsonpath='{.status.state}'=AtLatestKnown --timeout=60s
+OVMS_CSV=$(oc get subscription ovms-operator -n openshift-operators -o jsonpath='{.status.installedCSV}')
+oc wait csv/${OVMS_CSV} -n openshift-operators --for=jsonpath='{.status.phase}'=Succeeded --timeout=60s
 
 oc apply -f "${DIR}/intel/AIKitContainer-resource.yaml"
 oc apply -f "${DIR}/intel/openvino-notebook-resource.yaml"


### PR DESCRIPTION
Wait for subscription and dynamically read CSV on install.
Consistently use jsonpath instead of go-template.
Use installedCSV instead of currentCSV.